### PR TITLE
Fix wrapper to use exports instead of module.

### DIFF
--- a/lib/codesurgeon.js
+++ b/lib/codesurgeon.js
@@ -198,7 +198,7 @@ Codesurgeon.prototype.wrap = function (options) {
 
   options = options || {};
 
-  var detectionExpression = 'typeof process !== "undefined" && process.title ? module : window';
+  var detectionExpression = 'typeof exports === "object" ? exports : window';
 
   var args        = options.arguments || 'exports',
       params      = options.params || detectionExpression,


### PR DESCRIPTION
Without this change, the resulting code does things like `module.Router = Router` (in flatiron/director), which is of course useless.

This change gets us 90% of the way to solving flatiron/director#126.
