### PR TITLE
Add `noVersion` option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ The constructor function provides an instance of the Codesurgen.
   @param conf {Object} a json object literal that can contain configuration options.
     @member encoding {String} the encoding that will be used to product the result.
     @member quiet {String} indicate how much logging you want Codesurgen to produce.
+    @member noVersion {Boolean} true if you don't want Codesurgeon to automatically version your output filename.
 ```
 
 ## Instance Methods

--- a/lib/codesurgeon.js
+++ b/lib/codesurgeon.js
@@ -475,7 +475,7 @@ Codesurgeon.prototype.write = function (file, callback, flags) {
   !this.options.quiet && console.log('Write file [' + file.green + ']');
 
   if(this.packageJSON) {
-    if(file.substr(-3) === '.js') {
+    if(!this.options.noVersion && file.substr(-3) === '.js') {
 
       //
       // assume that the part of the name before the first dot is the name


### PR DESCRIPTION
Having to update the filename references to one's built file every time a new version is released has caused flatiron/director lots and lots of pain. Turning this off would be nice, without losing the `packageJSON` features.
